### PR TITLE
Avoiding an open <h2>tag when entry-info is hidden

### DIFF
--- a/zinnia_bootstrap/templates/zinnia/_entry_detail_base.html
+++ b/zinnia_bootstrap/templates/zinnia/_entry_detail_base.html
@@ -2,8 +2,8 @@
 <article id="entry-{{ object.pk }}" class="hentry{% if object.featured %} featured{% endif %}">
   {% block entry-header %}
   <header class="entry-header page-header">
-    {% block entry-title %}
     <h2 class="entry-title">
+    {% block entry-title %}
       <a href="{{ object.get_absolute_url }}" title="{{ object.title }}" rel="bookmark">
         {{ object.title|widont }}
       </a>
@@ -40,8 +40,8 @@
         {% endwith %}
         {% endblock entry-categories %}
       </small>
-    </h2>
     {% endblock entry-info %}
+    </h2>
     {% block entry-last-update %}
     <p class="entry-last-update" style="display: none;">
       {% trans "Last update on" %} <time class="updated" datetime="{{ object.last_update|date:"c" }}">{{ object.last_update|date:"DATE_FORMAT" }}</time>.


### PR DESCRIPTION
I was doing {% block entry-info %} {% endblock entryinfo%} in my custom template and found that <h2> was open when I was fixing the css. This should avoid the problem.
