### PR TITLE
Fixes for firstof an cycle tags

### DIFF
--- a/zinnia_bootstrap/templates/comments/zinnia/entry/form.html
+++ b/zinnia_bootstrap/templates/comments/zinnia/entry/form.html
@@ -1,5 +1,4 @@
 {% load comments i18n %}
-{% load firstof from future %}
 <form action="{% comment_form_target %}" method="post" id="comment-form" class="well form-horizontal">
   <div>{% csrf_token %}</div>
   {% if form.non_field_errors %}

--- a/zinnia_bootstrap/templates/zinnia/entry_detail_base.html
+++ b/zinnia_bootstrap/templates/zinnia/entry_detail_base.html
@@ -66,7 +66,7 @@
   {% block pingbacks-loop %}
   <ol id="pingback-list" class="list-group">
     {% for pingback in pingback_list %}
-    <li id="pingback-{{ pingback.pk }}" class="pingback vcard list-group-item {% cycle box1,box2 %}">
+    <li id="pingback-{{ pingback.pk }}" class="pingback vcard list-group-item {% cycle "box1" "box2" %}">
       {% block pingback-info %}
       <p class="pingback-info">
 	<a href="{{ pingback.url }}" rel="external nofollow"
@@ -111,7 +111,7 @@
   {% block trackbacks-loop %}
   <ol id="trackback-list" class="list-group">
     {% for trackback in trackback_list %}
-    <li id="trackback-{{ trackback.pk }}" class="trackback vcard list-group-item {% cycle box1,box2 %}">
+    <li id="trackback-{{ trackback.pk }}" class="trackback vcard list-group-item {% cycle "box1" "box2" %}">
       {% block trackback-info %}
       <p class="trackback-info">
 	<a href="{{ trackback.url }}" rel="external nofollow"
@@ -158,7 +158,7 @@
   <ol id="comment-list" class="list-group">
     {% for comment in comment_list %}
     <li id="comment-{{ comment.pk }}-by-{{ comment.user_name|slugify }}"
-        class="comment vcard list-group-item {% cycle box1,box2 %}{% if comment.user %} authenticated-comment{% if comment.user.is_staff %} staff-comment{% endif %}{% if comment.user.is_superuser %} superuser-comment{% endif %}{% endif %}">
+        class="comment vcard list-group-item {% cycle "box1" "box2" %}{% if comment.user %} authenticated-comment{% if comment.user.is_staff %} staff-comment{% endif %}{% if comment.user.is_superuser %} superuser-comment{% endif %}{% endif %}">
       {% block comment-info %}
       <p class="comment-info">
       {% block comment-image %}


### PR DESCRIPTION
This small commit should take care of some tag syntax errors in templates when rendering the entries.

I've created the fixeagainst the `develop` branch (since at least Django Blog Zinnia says one should create pull request for it against `develop` branch). Do let me know if I should create one for master too.